### PR TITLE
Add the support for converting emphasis markers.

### DIFF
--- a/zim-to-org.pl
+++ b/zim-to-org.pl
@@ -196,11 +196,31 @@ sub out_node {
     #
     # Convert checkbixes to orgmode format
     #
-    ~s/\[\*\]/\[X\]/g;
+    s/\[\*\]/\[X\]/g;
     #
     # Convert any starting '*' to '-' to save orgmode tree
     #
-    ~s/^\*/-/g;
+    s/^\*/-/g;
+    #
+    # Convert bold markers to orgmode format
+    #
+    s/^-\*([^\*]+)\*\*/\*$1\*/g;
+    s/\*\*([^\*]+)\*\*/\*$1\*/g;
+    #
+    # Convert italic markers to orgmode format
+    #
+    s/\/\/([^\/]+)\/\//\/$1\//g;
+    #
+    # Convert underlined markers to orgmode format
+    #
+    s/__([^\_]+)__/_$1_/g;
+    #
+    # Convert strike-through markers to orgmode format
+    #
+    s/~~([^\~]+)~~/\+$1\+/g;
+    #
+    # Convert verbatim markers to orgmode format
+    s/''([^\']+)''/=$1=/g;
     #
     # Convert zim headers to orgmode subtrees
     #


### PR DESCRIPTION
I just added several lines of regular expressions to convert the format of emphasis markers. It works fine when bold words are put at the beginning of a line.

```
**bold** => *bold*
//italic// => /italic/
__underlined__ => _underlined_
~~strike-through~~ => +strike-through+
''verbatim'' => =verbatim=
```